### PR TITLE
Add Debian boot screen and boot simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,172 +13,177 @@
 </head>
 
 <body>
-
-    <div id="topbar">
-        <div class="top-left">
-        </div>
-        <div class="top-right">
-            <div class="sys-item">
-                <img src="./src/icons/audio-volume-low.png" class="sys-icon">
-            </div>
-            <div class="sys-item">
-                <span id="clock"></span>
-            </div>
-        </div>
+    <div id="debian-boot-screen">
+        <div class="header">Debian GNU/Linux 12 (bookworm)</div>
+        <div id="boot-log-container"></div>
     </div>
 
-
-    <div class="window" id="terminal" style="top:80px; left:40px; width:380px;">
-        <div class="titlebar" onmousedown="drag(event, 'terminal')">
-            Terminal - victxrlarixs@Debian
-            <div class="close-btn" onclick="terminal.style.display='none'">
-                <img src="./src/icons/tab_close.png">
+    <div id="desktop-ui">
+        <div id="topbar">
+            <div class="top-left">
             </div>
-        </div>
-        <div class="terminal-body" id="terminalBody"></div>
-
-    </div>
-
-
-    <div class="window" id="fm" style="top:100px; left:460px; width:420px; height:320px; display:none;">
-        <div class="titlebar" onmousedown="drag(event, 'fm')">
-            victxrlarixs
-            <div class="close-btn" onclick="closeFileManager()">
-                <img src="./src/icons/tab_close.png">
+            <div class="top-right">
+                <div class="sys-item">
+                    <img src="./src/icons/audio-volume-low.png" class="sys-icon">
+                </div>
+                <div class="sys-item">
+                    <span id="clock"></span>
+                </div>
             </div>
         </div>
 
-        <div class="fm-container">
-            <div class="fm-menubar">
-                <span>File</span>
-                <span>Edit</span>
-                <span>View</span>
-                <span>Go</span>
-                <span>Help</span>
+
+        <div class="window" id="terminal" style="top:80px; left:40px; width:380px;">
+            <div class="titlebar" onmousedown="drag(event, 'terminal')">
+                Terminal - victxrlarixs@Debian
+                <div class="close-btn" onclick="terminal.style.display='none'">
+                    <img src="./src/icons/tab_close.png">
+                </div>
+            </div>
+            <div class="terminal-body" id="terminalBody"></div>
+
+        </div>
+
+
+        <div class="window" id="fm" style="top:100px; left:460px; width:420px; height:320px; display:none;">
+            <div class="titlebar" onmousedown="drag(event, 'fm')">
+                victxrlarixs
+                <div class="close-btn" onclick="closeFileManager()">
+                    <img src="./src/icons/tab_close.png">
+                </div>
             </div>
 
-            <div class="fm-toolbar">
-                <button class="fm-btn" onclick="goBack()">
-                    <img src="./src/icons/previous.png" alt="Back">
-                </button>
-                <button class="fm-btn" onclick="goForward()">
-                    <img src="./src/icons/right.png" alt="Forward">
-                </button>
-                <button class="fm-btn" onclick="goUp()">
-                    <img src="./src/icons/go-up.png" alt="Up">
-                </button>
-                <button class="fm-btn" onclick="goHome()">
-                    <img src="./src/icons/gohome.png" alt="Home">
-                </button>
-                <input class="fm-path" id="fmPath" />
+            <div class="fm-container">
+                <div class="fm-menubar">
+                    <span>File</span>
+                    <span>Edit</span>
+                    <span>View</span>
+                    <span>Go</span>
+                    <span>Help</span>
+                </div>
+
+                <div class="fm-toolbar">
+                    <button class="fm-btn" onclick="goBack()">
+                        <img src="./src/icons/previous.png" alt="Back">
+                    </button>
+                    <button class="fm-btn" onclick="goForward()">
+                        <img src="./src/icons/right.png" alt="Forward">
+                    </button>
+                    <button class="fm-btn" onclick="goUp()">
+                        <img src="./src/icons/go-up.png" alt="Up">
+                    </button>
+                    <button class="fm-btn" onclick="goHome()">
+                        <img src="./src/icons/gohome.png" alt="Home">
+                    </button>
+                    <input class="fm-path" id="fmPath" />
+                </div>
+
+                <div class="fm-body">
+                    <div class="fm-sidebar">
+                        <div class="fm-section">Places</div>
+                        <div class="fm-item" onclick="openPath('/home/victxrlarixs/')">
+                            <img src="./src/icons/gohome.png" class="fm-icon"> victxrlarixs
+                        </div>
+                        <div class="fm-item" onclick="openPath('/home/victxrlarixs/Desktop/')">
+                            <img src="./src/icons/desktop.png" class="fm-icon"> Desktop
+                        </div>
+                        <div class="fm-item">
+                            <img src="./src/icons/user-trash-full.png" class="fm-icon"> Trash
+                        </div>
+
+                        <div class="fm-section">Devices</div>
+                        <div class="fm-item">
+                            <img src="./src/icons/drive-harddisk.png" class="fm-icon"> File System
+                        </div>
+
+                        <div class="fm-section">Network</div>
+                        <div class="fm-item">
+                            <img src="./src/icons/redhat-system-group.png" class="fm-icon"> Browse Network
+                        </div>
+                    </div>
+
+                    <div class="fm-files" id="fmFiles"></div>
+                </div>
+
+                <div class="fm-status" id="fmStatus"></div>
             </div>
+        </div>
+        <div id="cde-panel">
+            <div class="cde-menu-btn">
+                <img src="./src/images/Debian.png" alt="Menu">
+            </div>
+            <div class="cde-sep"></div>
 
-            <div class="fm-body">
-                <div class="fm-sidebar">
-                    <div class="fm-section">Places</div>
-                    <div class="fm-item" onclick="openPath('/home/victxrlarixs/')">
-                        <img src="./src/icons/gohome.png" class="fm-icon"> victxrlarixs
-                    </div>
-                    <div class="fm-item" onclick="openPath('/home/victxrlarixs/Desktop/')">
-                        <img src="./src/icons/desktop.png" class="fm-icon"> Desktop
-                    </div>
-                    <div class="fm-item">
-                        <img src="./src/icons/user-trash-full.png" class="fm-icon"> Trash
-                    </div>
-
-                    <div class="fm-section">Devices</div>
-                    <div class="fm-item">
-                        <img src="./src/icons/drive-harddisk.png" class="fm-icon"> File System
-                    </div>
-
-                    <div class="fm-section">Network</div>
-                    <div class="fm-item">
-                        <img src="./src/icons/redhat-system-group.png" class="fm-icon"> Browse Network
+            <div class="cde-icon-block">
+                <div class="cde-icon-buttons">
+                    <div class="cde-icon-btn"></div>
+                    <div class="cde-icon-btn"></div>
+                    <div class="cde-icon-btn"></div>
+                    <div class="cde-icon-btn"></div>
+                    <div class="cde-icon-btn dropdown-btn" id="utilitiesBtn">
+                        <img src="./src/icons/go-up.png" alt="arrow" class="arrow-icon">
                     </div>
                 </div>
 
-                <div class="fm-files" id="fmFiles"></div>
-            </div>
-
-            <div class="fm-status" id="fmStatus"></div>
-        </div>
-    </div>
-    <div id="cde-panel">
-        <div class="cde-menu-btn">
-            <img src="./src/images/Debian.png" alt="Menu">
-        </div>
-        <div class="cde-sep"></div>
-
-        <div class="cde-icon-block">
-            <div class="cde-icon-buttons">
-                <div class="cde-icon-btn"></div>
-                <div class="cde-icon-btn"></div>
-                <div class="cde-icon-btn"></div>
-                <div class="cde-icon-btn"></div>
-                <div class="cde-icon-btn dropdown-btn" id="utilitiesBtn">
-                    <img src="./src/icons/go-up.png" alt="arrow" class="arrow-icon">
+                <div class="cde-icons">
+                    <div class="cde-icon" onclick="terminal.style.display='block'">
+                        <img src="./src/icons/konsole.png" alt="Terminal">
+                    </div>
+                    <div class="cde-icon" onclick="toggleFileManager()">
+                        <img src="./src/icons/filemanager.png" alt="File Manager">
+                    </div>
+                    <div class="cde-icon">
+                        <a href="https://github.com/Victxrlarixs/debian-cde" target="_blank">
+                            <img src="./src/icons/konqueror.png" alt="Browser">
+                        </a>
+                    </div>
+                    <div class="cde-icon" onclick="openStyleManager()">
+                        <img src="./src/icons/org.xfce.settings.appearance.png" alt="Style Manager">
+                    </div>
+                    <div class="cde-icon" id="utilitiesIcon">
+                        <img src="./src/icons/system-help.png" alt="Utilities">
+                    </div>
                 </div>
             </div>
+
+            <div class="dropdown-menu" id="utilitiesDropdown">
+                <div class="menu-item" onclick="terminal.style.display='block'">
+                    <img src="./src/icons/konsole.png" alt=""> Terminal
+                </div>
+            </div>
+
+            <div class="cde-sep"></div>
+
+            <div class="cde-pager">
+                <div class="pager-workspace active">One</div>
+                <div class="pager-workspace">Two</div>
+                <div class="pager-workspace">Three</div>
+                <div class="pager-workspace">Four</div>
+            </div>
+
+            <div class="cde-scroll">
+                <div class="scroll-btn">▲</div>
+                <div class="scroll-btn">▼</div>
+            </div>
+
+            <div class="cde-sep"></div>
 
             <div class="cde-icons">
-                <div class="cde-icon" onclick="terminal.style.display='block'">
-                    <img src="./src/icons/konsole.png" alt="Terminal">
+                <div class="tray-icon">
+                    <img src="./src/icons/gtkclocksetup.png" alt="Reloj">
                 </div>
-                <div class="cde-icon" onclick="toggleFileManager()">
-                    <img src="./src/icons/filemanager.png" alt="File Manager">
+                <div class="tray-icon">
+                    <img src="./src/icons/org.xfce.screenshooter.png" alt="Camera">
                 </div>
-                <div class="cde-icon">
-                    <a href="https://github.com/Victxrlarixs/debian-cde" target="_blank">
-                        <img src="./src/icons/konqueror.png" alt="Browser">
-                    </a>
+                <div class="tray-icon">
+                    <img src="./src/icons/printer.png" alt="Printer">
+
                 </div>
-                <div class="cde-icon" onclick="openStyleManager()">
-                    <img src="./src/icons/org.xfce.settings.appearance.png" alt="Style Manager">
-                </div>
-                <div class="cde-icon" id="utilitiesIcon">
-                    <img src="./src/icons/system-help.png" alt="Utilities">
+                <div class="tray-icon">
+                    <img src="./src/icons/org.xfce.taskmanager.png" alt="TaskManager">
                 </div>
             </div>
         </div>
-
-        <div class="dropdown-menu" id="utilitiesDropdown">
-            <div class="menu-item" onclick="terminal.style.display='block'">
-                <img src="./src/icons/konsole.png" alt=""> Terminal
-            </div>
-        </div>
-
-        <div class="cde-sep"></div>
-
-        <div class="cde-pager">
-            <div class="pager-workspace active">One</div>
-            <div class="pager-workspace">Two</div>
-            <div class="pager-workspace">Three</div>
-            <div class="pager-workspace">Four</div>
-        </div>
-
-        <div class="cde-scroll">
-            <div class="scroll-btn">▲</div>
-            <div class="scroll-btn">▼</div>
-        </div>
-
-        <div class="cde-sep"></div>
-
-        <div class="cde-icons">
-            <div class="tray-icon">
-                <img src="./src/icons/gtkclocksetup.png" alt="Reloj">
-            </div>
-            <div class="tray-icon">
-                <img src="./src/icons/org.xfce.screenshooter.png" alt="Camera">
-            </div>
-            <div class="tray-icon">
-                <img src="./src/icons/printer.png" alt="Printer">
-
-            </div>
-            <div class="tray-icon">
-                <img src="./src/icons/org.xfce.taskmanager.png" alt="TaskManager">
-            </div>
-        </div>
-    </div>
 
     </div>
     <div class="cde-retro-modal" id="styleManager">
@@ -374,6 +379,7 @@
             <button class="cde-btn" onclick="styleManager.save()">Save</button>
             <button class="cde-btn" onclick="styleManager.close()">Close</button>
         </div>
+    </div>
     </div>
 
     <script src="./src/js/init.js"></script>

--- a/src/css/core.css
+++ b/src/css/core.css
@@ -133,3 +133,84 @@ body {
 * {
     cursor: url('../icons/cursor.svg'), auto;
 }
+
+/* Ocultar escritorio hasta que el boot termine */
+#desktop-ui {
+    display: none;
+}
+
+/* Pantalla de boot: visible desde el primer momento */
+#debian-boot-screen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #000000;
+    color: #AAAAAA;
+    font-family: 'DejaVu Sans Mono', monospace;
+    font-size: 12px;
+    line-height: 1.1;
+    z-index: 99999;
+    padding: 10px;
+    box-sizing: border-box;
+    opacity: 1;
+    transition: opacity 0.5s ease-out;
+}
+
+#debian-boot-screen .header {
+    color: #00AA00;
+    border-bottom: 1px solid #333333;
+    padding-bottom: 5px;
+    margin-bottom: 10px;
+    font-weight: bold;
+}
+
+#boot-log-container {
+    height: calc(100% - 30px);
+    overflow-y: auto;
+    font-family: monospace;
+}
+
+@keyframes bootLineAppear {
+    to {
+        opacity: 1;
+    }
+}
+
+.boot-kernel {
+    color: #CCCCCC;
+}
+
+.boot-cpu {
+    color: #88AAFF;
+}
+
+.boot-memory {
+    color: #FFAA88;
+}
+
+.boot-fs {
+    color: #FFFF88;
+}
+
+.boot-systemd {
+    color: #88FFFF;
+}
+
+.boot-service {
+    color: #00FF00;
+}
+
+.boot-drm {
+    color: #FF8888;
+}
+
+.boot-desktop {
+    color: #00FFAA;
+    font-weight: bold;
+}
+
+.boot-default {
+    color: #AAAAAA;
+}

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -1,182 +1,169 @@
-// init.js - Archivo principal de inicialización
+/**
+ * @fileoverview Simulación de arranque Debian CDE.
+ * Gestiona la secuencia de boot (duración total ~10s) y la inicialización del escritorio.
+ * @author victxrlarixs
+ */
 
 let desktopInitialized = false;
 
-// ==================== BOOT LOADER ====================
-
+/**
+ * Simula el arranque de un sistema Debian con CDE.
+ * Muestra mensajes estilo kernel en #boot-log-container y finaliza
+ * revelando el escritorio (#desktop-ui).
+ */
 class DebianRealBoot {
     constructor() {
+        /** @type {number} Índice del paso actual en la secuencia */
         this.currentStep = 0;
+
+        /** @type {Array<{delay: number, text: string, type: string}>} */
         this.bootSequence = [
-            { delay: 200, text: "[    0.000000] Linux version 6.1.0-18-amd64", type: "kernel" },
-            { delay: 300, text: "[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-6.1.0-18-amd64", type: "kernel" },
-            { delay: 250, text: "[    0.000000] x86/fpu: Supporting XSAVE feature 0x001", type: "cpu" },
-            { delay: 350, text: "[    0.227156] smpboot: CPU0: Intel(R) Core(TM) i5-10400 CPU", type: "cpu" },
-            { delay: 400, text: "[    0.789123] Memory: 15904964K/16777216K available", type: "memory" },
-            { delay: 450, text: "[    1.012345] EXT4-fs (sda1): mounted filesystem", type: "fs" },
-            { delay: 420, text: "[    1.123456] systemd[1]: systemd 252.19-1~deb12u1", type: "systemd" },
-            { delay: 500, text: "[    1.234567] systemd[1]: Detected architecture x86-64.", type: "systemd" },
-            { delay: 380, text: "[    1.345678] systemd[1]: Set hostname to <debian-cde>.", type: "systemd" },
-            { delay: 520, text: "[    2.112345] i915 0000:00:02.0: [drm] VT-d active", type: "drm" },
-            { delay: 550, text: "[    2.667890] systemd[1]: Starting Load/Save Random Seed...", type: "service" },
-            { delay: 520, text: "[    2.778901] systemd[1]: Started Load/Save Random Seed.", type: "service" },
-            { delay: 700, text: "[    4.000000] Starting CDE Desktop Environment...", type: "desktop" },
-            { delay: 680, text: "[    4.111111] Loading Common Desktop Environment...", type: "desktop" },
-            { delay: 720, text: "[    4.222222] Initializing dtlogin manager...", type: "desktop" },
-            { delay: 750, text: "[    4.444444] Loading Workspace Manager...", type: "desktop" },
-            { delay: 730, text: "[    4.555555] Starting dtwm window manager...", type: "desktop" },
-            { delay: 780, text: "[    4.666666] Initializing Front Panel...", type: "desktop" },
-            { delay: 800, text: "[    4.888888] Starting File Manager services...", type: "desktop" },
-            { delay: 790, text: "[    5.000000] CDE initialization complete.", type: "desktop" },
+            { delay: 177, text: "[    0.000000] Iniciando simulación Debian CDE [debian.com.mx]", type: "kernel" },
+            { delay: 221, text: "[    0.227156] smpboot: CPU0: Motor Retro de Renderizado (compatibilidad 1995)", type: "cpu" },
+            { delay: 310, text: "[    0.789123] Memoria: 64MB de nostalgia noventera disponible", type: "memory" },
+            { delay: 354, text: "[    1.012345] Montando /usr/share/cde/icons ...", type: "fs" },
+            { delay: 399, text: "[    1.123456] Cargando temas: Platinum, Olive, Marine...", type: "fs" },
+            { delay: 372, text: "[    1.345678] Iniciando Style Manager (esquemas de color)", type: "systemd" },
+            { delay: 443, text: "[    1.789012] Iniciando Workspace Manager: pager listo", type: "systemd" },
+            { delay: 337, text: "[    2.112345] i915: Inicializando filtro CRT retro", type: "drm" },
+            { delay: 461, text: "[    2.667890] Iniciando dtlogin: administrador de sesión CDE (auto-login: victxrlarixs)", type: "service" },
+            { delay: 487, text: "[    2.778901] Cargando Panel CDE: selector de espacios, iconos, bandeja", type: "service" },
+            { delay: 461, text: "[    3.123456] Iniciando Gestor de Archivos", type: "service" },
+            { delay: 638, text: "[    4.111111] dtwm: Gestor de ventanas inicializado", type: "desktop" },
+            { delay: 664, text: "[    4.222222] Espacio de trabajo Uno: activo", type: "desktop" },
+            { delay: 647, text: "[    4.444444] Style Manager: escuchando cambios de color", type: "desktop" },
+            { delay: 700, text: "[    5.000000] Escritorio CDE listo ....", type: "desktop" },
         ];
+
+        /** @type {Array<string>} Historial de líneas mostradas */
         this.bootLog = [];
+
+        /** @type {HTMLElement|null} Contenedor donde se escriben las líneas */
+        this.container = document.getElementById('boot-log-container');
+
+        /** @type {HTMLElement|null} Pantalla completa de boot */
+        this.bootScreen = document.getElementById('debian-boot-screen');
     }
 
-    show() {
-        const existingBootScreen = document.getElementById('debian-boot-screen');
-        if (existingBootScreen) existingBootScreen.remove();
+    /**
+     * Inicia la secuencia de arranque.
+     * Limpia el contenedor y ejecuta la reproducción de pasos.
+     */
+    start() {
+        this.currentStep = 0;
+        this.bootLog = [];
 
-        const bootScreen = document.createElement('div');
-        bootScreen.id = 'debian-boot-screen';
-        bootScreen.style.cssText = `
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: #000000;
-            color: #AAAAAA;
-            font-family: 'DejaVu Sans Mono', monospace;
-            font-size: 12px;
-            line-height: 1.1;
-            z-index: 99999;
-            padding: 10px;
-            box-sizing: border-box;
-        `;
+        if (!this.container) {
+            console.error('❌ No se encontró #boot-log-container');
+            this.completeBoot();
+            return;
+        }
 
-        const header = document.createElement('div');
-        header.style.cssText = `
-            color: #00AA00;
-            border-bottom: 1px solid #333333;
-            padding-bottom: 5px;
-            margin-bottom: 10px;
-            font-weight: bold;
-        `;
-        header.textContent = 'Debian GNU/Linux 12 (bookworm)';
-        bootScreen.appendChild(header);
-
-        const logContainer = document.createElement('div');
-        logContainer.id = 'boot-log-container';
-        logContainer.style.cssText = `
-            height: calc(100% - 30px);
-            overflow-y: auto;
-            font-family: monospace;
-        `;
-
-        bootScreen.appendChild(logContainer);
-        document.body.appendChild(bootScreen);
-
-        this.startBootSequence(logContainer);
+        this.container.innerHTML = '';
+        this.startBootSequence();
     }
 
-    startBootSequence(container) {
+    /**
+     * Reproduce recursivamente cada línea de la secuencia.
+     * @private
+     */
+    startBootSequence() {
         const showNextStep = () => {
             if (this.currentStep >= this.bootSequence.length) {
-                setTimeout(() => this.completeBoot(), 500);
+                setTimeout(() => this.completeBoot(), 443); // ~0.44s para total 10s
                 return;
             }
 
             const step = this.bootSequence[this.currentStep];
-            const lineElement = document.createElement('div');
-            lineElement.style.cssText = `
+            const line = document.createElement('div');
+            line.className = this.getLineClass(step.type);
+            line.style.cssText = `
                 opacity: 0;
                 animation: bootLineAppear 0.1s forwards;
                 white-space: pre-wrap;
-                ${this.getLineStyle(step.type)}
             `;
-            lineElement.textContent = step.text;
-            container.appendChild(lineElement);
-            container.scrollTop = container.scrollHeight;
+            line.textContent = step.text;
+
+            this.container.appendChild(line);
+            this.container.scrollTop = this.container.scrollHeight;
             this.bootLog.push(step.text);
             this.currentStep++;
 
             setTimeout(showNextStep, step.delay);
         };
-
         showNextStep();
     }
 
-    getLineStyle(type) {
-        const styles = {
-            'kernel': 'color: #CCCCCC;',
-            'cpu': 'color: #88AAFF;',
-            'memory': 'color: #FFAA88;',
-            'fs': 'color: #FFFF88;',
-            'systemd': 'color: #88FFFF;',
-            'service': 'color: #00FF00;',
-            'drm': 'color: #FF8888;',
-            'desktop': 'color: #00FFAA; font-weight: bold;',
+    /**
+     * Devuelve el nombre de clase CSS según el tipo de mensaje.
+     * @param {string} type
+     * @returns {string} Nombre de clase (ej. 'boot-kernel')
+     */
+    getLineClass(type) {
+        const map = {
+            'kernel': 'boot-kernel',
+            'cpu': 'boot-cpu',
+            'memory': 'boot-memory',
+            'fs': 'boot-fs',
+            'systemd': 'boot-systemd',
+            'service': 'boot-service',
+            'drm': 'boot-drm',
+            'desktop': 'boot-desktop',
         };
-        return styles[type] || 'color: #AAAAAA;';
+        return map[type] || 'boot-default';
     }
 
+    /**
+     * Finaliza el boot: oculta la pantalla negra, muestra el escritorio
+     * e invoca la inicialización de componentes.
+     */
     completeBoot() {
-        const bootScreen = document.getElementById('debian-boot-screen');
-        if (!bootScreen) return;
+        if (this.bootScreen) {
+            this.bootScreen.style.transition = 'opacity 0.5s ease-out';
+            this.bootScreen.style.opacity = '0';
 
-        bootScreen.style.transition = 'opacity 0.5s ease-out';
-        bootScreen.style.opacity = '0';
-
-        setTimeout(() => {
-            if (bootScreen.parentNode) bootScreen.remove();
+            setTimeout(() => {
+                this.bootScreen.style.display = 'none';
+                const desktop = document.getElementById('desktop-ui');
+                if (desktop) desktop.style.display = 'block';
+                initDesktop();
+            }, 500);
+        } else {
             initDesktop();
-        }, 500);
-    }
-
-    start() {
-        this.currentStep = 0;
-        this.bootLog = [];
-        this.show();
+        }
     }
 }
 
-// ==================== DESKTOP INITIALIZATION ====================
-
+/**
+ * Inicializa todos los módulos del escritorio CDE.
+ * Se ejecuta una sola vez tras completar el boot.
+ */
 function initDesktop() {
     if (desktopInitialized) return;
 
     console.log('🖥️ Initializing CDE Desktop Environment...');
 
-    // Inicializar componentes si existen
     if (typeof initClock === 'function') initClock();
     if (typeof initTerminal === 'function') initTerminal();
     if (typeof initWindowManager === 'function') initWindowManager();
     if (typeof initUI === 'function') initUI();
-    if (window.styleManager && typeof window.styleManager.init === 'function') {
-        window.styleManager.init();
-    }
+    if (window.styleManager?.init === 'function') window.styleManager.init();
 
     desktopInitialized = true;
     console.log('✅ CDE Desktop initialized successfully!');
 }
 
-// ==================== MAIN INITIALIZATION ====================
-
+// ---------------------------------------------------------------------
+// Arranque automático al cargar el DOM
+// ---------------------------------------------------------------------
 document.addEventListener('DOMContentLoaded', () => {
     console.log('📄 DOM Content Loaded');
-
-    // Añadir estilos minimales
-    const bootStyles = document.createElement('style');
-    bootStyles.textContent = `@keyframes bootLineAppear { to { opacity: 1; } }`;
-    document.head.appendChild(bootStyles);
-
-    // Iniciar boot loader
     window.debianBoot = new DebianRealBoot();
-    setTimeout(() => window.debianBoot.start(), 300);
+    window.debianBoot.start();
 });
 
-// Funciones globales
+// Exposición global para acceso desde consola u otros módulos
 window.initDesktop = initDesktop;
 window.DebianRealBoot = DebianRealBoot;
 
-console.log('✅ init.js loaded successfully');
+console.log('✅ init.js loaded');


### PR DESCRIPTION
Introduce a simulated Debian boot experience and defer showing the desktop until boot completes. index.html: add #debian-boot-screen and wrap desktop markup in #desktop-ui, reformat window/panel structure. core.css: add styles for the boot screen, hide #desktop-ui initially, and provide color classes for boot message types. init.js: implement DebianRealBoot class with a timed bootSequence (Spanish messages), render boot log to #boot-log-container, fade out boot screen and reveal desktop, and refactor initDesktop/startup logic (guards, optional chaining, exposed globals). This provides a ~10s boot simulation and cleaner initialization flow.