### PR TITLE
ci: modernize deployment workflow to native GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,23 +3,30 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main branch
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -27,14 +34,25 @@ jobs:
       - name: Build Astro
         run: npm run build
 
-      - name: Add .nojekyll file
-        run: touch ./dist/.nojekyll
+      - name: Prepare Deployment
+        run: |
+          touch ./dist/.nojekyll
+          echo "debian.com.mx" > ./dist/CNAME
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          publish_branch: gh-pages
-          force_orphan: true
-          cname: debian.com.mx
+          path: ./dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+


### PR DESCRIPTION
- Migrated deployment from legacy gh-pages branch to native GitHub Actions.
- Enabled npm dependency caching for faster build times.
- Added concurrency control to prevent deployment collisions.
- Restricted permissions to follow security best practices.
- Added automated CNAME generation for debian.com.mx.
- Added workflow_dispatch for manual deployment triggers.