### PR TITLE
feat(emacs): complete interactive minibuffer implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ We've spent months ensuring the retro experience doesn't break on modern hardwar
 - **Interaction Parity**: Double-tap to open, long-press for context menus, and tap-to-focus for the terminal virtual keyboard.
 - **Zero-Overflow**: Strict window clamping ensures no horizontal scroll, ever.
 
+### 📟 GNU Emacs
+A core pillar of the Debian-CDE experience. Much more than a text editor, it's a faithful recreation of the classic environment:
+- **Interactive Minibuffer**: No pop-ups for system operations. All commands (`M-x`), file visits (`C-x C-f`), and saves (`C-x C-w`) happen natively in the interactive lower minibuffer.
+- **Classic Keybindings**: Support for `C-x`, `C-g` (abort), `C-k` (kill line), `M-w`/`C-y` (copy/paste), and many more.
+- **Visual Fidelity**: Accurate mode-line with line/column counters, file status indicators, and the iconic GNU Emacs splash screen.
+- **Scratch Buffer**: Starts with a fully functional `*scratch*` buffer for Lisp-style (or plain text) note-taking.
+
 ---
 
 ## 🎯 Iconic Experiences

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -1978,23 +1978,27 @@
   width: 100%;
 }
 
-#text-editor {
-  width: 600px;
-  height: 400px;
+#emacs {
+  width: 640px;
+  height: 480px;
   display: none;
   flex-direction: column;
 }
 
-#text-editor .titlebar {
+#emacs .titlebar {
+  background: var(--titlebar-color);
   flex-shrink: 0;
 }
 
-#text-editor .terminal-body {
-  flex: 1;
+#emacs .terminal-body {
+  background: #000;
+  color: #00ff00;
+  padding: 10px;
+  font-family: 'DejaVu Mono', monospace;
   overflow-y: auto;
+  flex: 1;
   white-space: pre-wrap;
   word-wrap: break-word;
-  padding: 10px;
   margin: 0;
 }
 
@@ -2943,7 +2947,7 @@
    EMACS TEXT EDITOR
    ------------------------------------------------------------------ */
 
-#text-editor {
+#emacs {
   width: min(760px, 100vw);
   height: min(580px, 90vh);
   max-width: 100vw;
@@ -3133,68 +3137,110 @@
   line-height: 1.5;
 }
 
-/* ── Editor Area ── */
-.emacs-editor {
+/* ── Editor Container & Area ── */
+#emacs-editor-area {
   flex: 1;
   display: flex;
   flex-direction: column;
   background: #fff;
+  border: 1px solid #bbb;
   overflow: hidden;
+  position: relative;
 }
 
-#text-editor-textarea {
+#emacs-textarea {
   flex: 1;
   background: #fff;
-  color: #000;
-  font-family: 'DejaVu Mono', 'Courier New', monospace;
-  font-size: 13px;
+  color: #000 !important;
+  font-family: 'DejaVu Mono', 'Courier New', monospace !important;
+  font-size: 13px !important;
   border: none;
   outline: none;
-  padding: 6px 10px;
+  padding: 10px;
   resize: none;
   line-height: 1.5;
   white-space: pre;
   tab-size: 4;
+  caret-shape: block; /* For browsers that support it */
 }
 
-/* ── Mode Line ── */
-.emacs-modeline {
-  background: #316ecb;
-  color: #fff;
+#emacs-textarea:focus {
+  outline: none;
+}
+
+/* ── Mode Line (Classic Gray) ── */
+#emacs-mode-line {
+  background: #bfbfbf;
+  color: #000;
   font-family: 'DejaVu Mono', monospace;
-  font-size: 12px;
+  font-size: 11px;
   height: 20px;
   line-height: 20px;
   padding: 0 8px;
   user-select: none;
   white-space: nowrap;
   overflow: hidden;
-  letter-spacing: 0.3px;
+  border-top: 1px solid #808080;
+  border-bottom: 2px solid #555;
+  font-weight: bold;
 }
 
 /* ── Shortcuts Hint ── */
-.emacs-shortcuts {
-  background: #1a1a1a;
-  color: #00e000;
+#emacs-shortcuts {
+  background: #222;
+  color: #00ff00;
   font-family: 'DejaVu Mono', monospace;
   font-size: 10px;
   height: 18px;
   line-height: 18px;
   padding: 0 8px;
   user-select: none;
-  letter-spacing: 0.4px;
+  letter-spacing: 0.5px;
 }
 
 /* ── Minibuffer ── */
-.emacs-minibuffer {
+#emacs-minibuffer {
   background: #fff;
   color: #000;
   font-family: 'DejaVu Mono', monospace;
   font-size: 13px;
-  height: 20px;
-  line-height: 20px;
+  height: 22px;
+  line-height: 22px;
   padding: 0 8px;
-  border-top: 1px solid #bbb;
+  border-top: 1px solid #aaa;
+  display: flex;
+  align-items: center;
+}
+
+#emacs-minibuffer-content {
+  display: none; /* Hidden by default, shown during prompt */
+  flex: 1;
+  align-items: center;
+}
+
+#emacs-minibuffer-label {
+  margin-right: 4px;
+  color: #555;
+  font-weight: bold;
+}
+
+#emacs-minibuffer-input {
+  flex: 1;
+  background: transparent;
+  color: #000;
+  border: none;
+  outline: none;
+  font-family: inherit;
+  font-size: inherit;
+  padding: 0;
+  margin: 0;
+}
+
+#emacs-minibuffer-msg {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* ── Menubar ── */
@@ -3324,70 +3370,6 @@
   color: #000;
 }
 
-/* ── Editor container ── */
-.editor-container {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  background: #fff;
-  border: 1px solid #bbb;
-  overflow: hidden;
-  position: relative;
-}
-
-#text-editor-textarea {
-  flex: 1;
-  background: #fff;
-  color: #000 !important;
-  font-family: 'DejaVu Mono', monospace !important;
-  font-size: 13px !important;
-  border: none;
-  outline: none;
-  padding: 10px;
-  resize: none;
-  line-height: 1.5;
-  white-space: pre;
-  tab-size: 4;
-}
-
-/* Mode Line */
-#text-editor-mode-line {
-  background: #316ecb;
-  color: #fff;
-  font-family: 'DejaVu Mono', monospace;
-  font-size: 12px;
-  height: 20px;
-  line-height: 20px;
-  padding: 0 8px;
-  user-select: none;
-  white-space: nowrap;
-  overflow: hidden;
-}
-
-/* Shortcuts hint bar */
-#text-editor-shortcuts {
-  background: #1a1a1a;
-  color: #00e000;
-  font-family: 'DejaVu Mono', monospace;
-  font-size: 10px;
-  height: 18px;
-  line-height: 18px;
-  padding: 0 8px;
-  user-select: none;
-  letter-spacing: 0.4px;
-}
-
-/* Minibuffer */
-#text-editor-minibuffer {
-  background: #fff;
-  color: #000;
-  font-family: 'DejaVu Mono', monospace;
-  font-size: 13px;
-  height: 20px;
-  line-height: 20px;
-  padding: 0 8px;
-  border-top: 1px solid #bbb;
-}
 
 .emacs-pixelated {
   image-rendering: pixelated;

--- a/src/components/desktop/Panel.astro
+++ b/src/components/desktop/Panel.astro
@@ -81,7 +81,7 @@ import { CONFIG } from '../../scripts/core/config';
     <img src="/icons/org.xfce.taskmanager.png" alt="TaskManager" />
   </div>
 
-  <div class="tray-icon" onclick="window.TextEditor?.openSplash()" title="Emacs">
+  <div class="tray-icon" onclick="window.Emacs?.openSplash()" title="Emacs">
     <img src="/icons/emacs22.png" alt="Emacs" class="emacs-pixelated" />
   </div>
 </div>
@@ -90,7 +90,7 @@ import { CONFIG } from '../../scripts/core/config';
   <div class="menu-item" onclick="captureFullPageScreenshot()">
     <img src="/icons/org.xfce.screenshooter.png" alt="" /> Screenshot
   </div>
-  <div class="menu-item" onclick="window.TextEditor?.openSplash()">
+  <div class="menu-item" onclick="window.Emacs?.openSplash()">
     <img src="/icons/emacs22.png" alt="" class="emacs-pixelated" /> Emacs
   </div>
   <div class="menu-item" onclick="openCalendar()">

--- a/src/components/features/AppManager.astro
+++ b/src/components/features/AppManager.astro
@@ -59,7 +59,7 @@ import WindowControls from '../common/WindowControls.astro';
       </div>
 
       <!-- Emacs -->
-      <div class="app-item" onclick="window.TextEditor?.openSplash(); appManager.close()">
+      <div class="app-item" onclick="window.Emacs?.openSplash(); appManager.close()">
         <img src="/icons/emacs22.png" alt="Emacs" class="emacs-pixelated" />
         <span>Emacs</span>
       </div>

--- a/src/components/features/Emacs.astro
+++ b/src/components/features/Emacs.astro
@@ -1,12 +1,12 @@
 ---
-// src/components/features/TextEditor.astro
+// src/components/features/Emacs.astro
 import WindowControls from '../common/WindowControls.astro';
 ---
 
-<div class="window" id="text-editor">
-  <div class="titlebar emacs-titlebar" id="text-editor-titlebar" onmousedown="window.drag(event, 'text-editor')">
-    <span class="titlebar-text" id="text-editor-title">*GNU Emacs*</span>
-    <WindowControls windowId="text-editor" closeFunction="window.closeTextEditor" />
+<div class="window" id="emacs" tabindex="-1">
+  <div class="titlebar emacs-titlebar" id="emacs-titlebar" onmousedown="window.drag(event, 'emacs')">
+    <span class="titlebar-text" id="emacs-title">*GNU Emacs*</span>
+    <WindowControls windowId="emacs" closeFunction="window.closeEmacs" />
   </div>
 
   <!-- ── Emacs Menubar ─────────────────────────────────────────────────── -->
@@ -15,41 +15,41 @@ import WindowControls from '../common/WindowControls.astro';
     <div class="te-menu">
       <span class="te-menu-label">File</span>
       <div class="te-dropdown">
-        <div class="te-item" onclick="window.TextEditor.openFile()">Open File…<span class="te-accel">C-x C-f</span></div>
+        <div class="te-item" onclick="window.Emacs.openFile()">Open File…<span class="te-accel">C-x C-f</span></div>
         <div class="te-item" onclick="window.openFileManager && window.openFileManager()">Open Home Directory</div>
         <div class="te-separator"></div>
-        <div class="te-item" onclick="window.TextEditor.save()">Save<span class="te-accel">C-x C-s</span></div>
-        <div class="te-item" onclick="window.TextEditor.saveAs()">Save As…<span class="te-accel">C-x C-w</span></div>
+        <div class="te-item" onclick="window.Emacs.save()">Save<span class="te-accel">C-x C-s</span></div>
+        <div class="te-item" onclick="window.Emacs.saveAs()">Save As…<span class="te-accel">C-x C-w</span></div>
         <div class="te-separator"></div>
-        <div class="te-item" onclick="window.TextEditor.newFile()">New File</div>
+        <div class="te-item" onclick="window.Emacs.newFile()">New File</div>
         <div class="te-separator"></div>
-        <div class="te-item" onclick="window.closeTextEditor()">Quit<span class="te-accel">C-x C-c</span></div>
+        <div class="te-item" onclick="window.closeEmacs()">Quit<span class="te-accel">C-x C-c</span></div>
       </div>
     </div>
 
     <div class="te-menu">
       <span class="te-menu-label">Edit</span>
       <div class="te-dropdown">
-        <div class="te-item" onclick="window.TextEditor.undo()">Undo<span class="te-accel">C-_</span></div>
+        <div class="te-item" onclick="window.Emacs.undo()">Undo<span class="te-accel">C-_</span></div>
         <div class="te-separator"></div>
-        <div class="te-item" onclick="window.TextEditor.cut()">Cut Region<span class="te-accel">C-w</span></div>
-        <div class="te-item" onclick="window.TextEditor.copy()">Copy Region<span class="te-accel">M-w</span></div>
-        <div class="te-item" onclick="window.TextEditor.paste()">Paste (Yank)<span class="te-accel">C-y</span></div>
+        <div class="te-item" onclick="window.Emacs.cut()">Cut Region<span class="te-accel">C-w</span></div>
+        <div class="te-item" onclick="window.Emacs.copy()">Copy Region<span class="te-accel">M-w</span></div>
+        <div class="te-item" onclick="window.Emacs.paste()">Paste (Yank)<span class="te-accel">C-y</span></div>
         <div class="te-separator"></div>
-        <div class="te-item" onclick="window.TextEditor.selectAll()">Select All<span class="te-accel">C-x h</span></div>
+        <div class="te-item" onclick="window.Emacs.selectAll()">Select All<span class="te-accel">C-x h</span></div>
         <div class="te-separator"></div>
-        <div class="te-item" onclick="window.TextEditor.findDialog()">Search…<span class="te-accel">C-s</span></div>
+        <div class="te-item" onclick="window.Emacs.findDialog()">Search…<span class="te-accel">C-s</span></div>
       </div>
     </div>
 
     <div class="te-menu">
       <span class="te-menu-label">Options</span>
       <div class="te-dropdown">
-        <div class="te-item" onclick="window.TextEditor.wrapToggle()">Toggle Word Wrap</div>
+        <div class="te-item" onclick="window.Emacs.wrapToggle()">Toggle Word Wrap</div>
         <div class="te-separator"></div>
-        <div class="te-item" onclick="window.TextEditor.setFont('14px')">Font Size: 14</div>
-        <div class="te-item" onclick="window.TextEditor.setFont('13px')">Font Size: 13</div>
-        <div class="te-item" onclick="window.TextEditor.setFont('11px')">Font Size: 11</div>
+        <div class="te-item" onclick="window.Emacs.setFont('14px')">Font Size: 14</div>
+        <div class="te-item" onclick="window.Emacs.setFont('13px')">Font Size: 13</div>
+        <div class="te-item" onclick="window.Emacs.setFont('11px')">Font Size: 11</div>
       </div>
     </div>
 
@@ -58,21 +58,21 @@ import WindowControls from '../common/WindowControls.astro';
       <div class="te-dropdown">
         <div class="te-item te-disabled" id="emacs-active-buffer">*GNU Emacs*</div>
         <div class="te-separator"></div>
-        <div class="te-item" onclick="window.TextEditor.clearBuffer()">Clear Buffer</div>
+        <div class="te-item" onclick="window.Emacs.clearBuffer()">Clear Buffer</div>
       </div>
     </div>
 
     <div class="te-menu">
       <span class="te-menu-label">Tools</span>
       <div class="te-dropdown">
-        <div class="te-item" onclick="window.TextEditor.findDialog()">Search Files<span class="te-accel">C-f</span></div>
+        <div class="te-item" onclick="window.Emacs.findDialog()">Search Files<span class="te-accel">C-f</span></div>
       </div>
     </div>
 
     <div class="te-menu">
       <span class="te-menu-label">Help</span>
       <div class="te-dropdown">
-        <div class="te-item" onclick="window.TextEditor.showHelp()">Describe Bindings</div>
+        <div class="te-item" onclick="window.Emacs.showHelp()">Describe Bindings</div>
         <div class="te-separator"></div>
         <div class="te-item te-disabled">About Emacs</div>
       </div>
@@ -84,9 +84,9 @@ import WindowControls from '../common/WindowControls.astro';
   <div id="te-find-bar" class="te-find-bar te-find-hidden">
     <label>I-search:</label>
     <input id="te-find-input" type="text" autocomplete="off" spellcheck="false" />
-    <button onclick="window.TextEditor.findNext()">↓</button>
-    <button onclick="window.TextEditor.findPrev()">↑</button>
-    <button onclick="window.TextEditor.closeFindBar()">✕</button>
+    <button onclick="window.Emacs.findNext()">↓</button>
+    <button onclick="window.Emacs.findPrev()">↑</button>
+    <button onclick="window.Emacs.closeFindBar()">✕</button>
   </div>
 
   <!-- ── Emacs Splash Screen ───────────────────────────────────────────── -->
@@ -97,14 +97,14 @@ import WindowControls from '../common/WindowControls.astro';
     </div>
 
     <div class="emacs-splash-welcome">
-      Welcome to <a class="emacs-link" onclick="window.TextEditor.showHelp()">GNU Emacs</a>,
+      Welcome to <a class="emacs-link" onclick="window.Emacs.showHelp()">GNU Emacs</a>,
       one component of the <a class="emacs-link" href="https://www.gnu.org/gnu/linux-and-gnu.html" target="_blank">GNU/Linux</a> operating system.
     </div>
 
     <div class="emacs-splash-links">
       <table>
         <tr>
-          <td><a class="emacs-link" onclick="window.TextEditor.openFile()">Open a File</a></td>
+          <td><a class="emacs-link" onclick="window.Emacs.openFile()">Open a File</a></td>
           <td>Open a file to edit in this buffer</td>
         </tr>
         <tr>
@@ -125,16 +125,8 @@ import WindowControls from '../common/WindowControls.astro';
           <td>View the Emacs manual online</td>
         </tr>
         <tr>
-          <td><a class="emacs-link" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/No-Warranty.html" target="_blank">Absence of Warranty</a></td>
-          <td>GNU Emacs comes with <em>ABSOLUTELY NO WARRANTY</em></td>
-        </tr>
-        <tr>
           <td><a class="emacs-link" href="https://www.gnu.org/software/emacs/manual/html_node/emacs/Copying.html" target="_blank">Copying Conditions</a></td>
           <td>Conditions for redistributing and changing Emacs</td>
-        </tr>
-        <tr>
-          <td><a class="emacs-link" href="https://shop.fsf.org/" target="_blank">Ordering Manuals</a></td>
-          <td>Purchasing printed copies of manuals</td>
         </tr>
       </table>
     </div>
@@ -151,21 +143,27 @@ import WindowControls from '../common/WindowControls.astro';
   </div><!-- /splash -->
 
   <!-- ── Editing Area (hidden until file is opened) ────────────────────── -->
-  <div id="emacs-editor" class="emacs-editor emacs-hidden">
-    <textarea id="text-editor-textarea" spellcheck="false" autocomplete="off"></textarea>
+  <div id="emacs-editor-area" class="emacs-editor emacs-hidden">
+    <textarea id="emacs-textarea" spellcheck="false" autocomplete="off"></textarea>
   </div>
 
   <!-- ── Mode Line ─────────────────────────────────────────────────────── -->
-  <div id="text-editor-mode-line" class="emacs-modeline">
-    U:%%─&nbsp;&nbsp;<span id="editor-file-status">──</span>&nbsp;&nbsp;<span id="editor-file-name">*GNU Emacs*</span>&nbsp;&nbsp;All&nbsp;&nbsp;L<span id="editor-line">1</span>&nbsp;&nbsp;(<span id="editor-mode">Fundamental</span>)
+  <div id="emacs-mode-line" class="emacs-modeline">
+    U:%%─&nbsp;&nbsp;<span id="emacs-file-status">──</span>&nbsp;&nbsp;<span id="emacs-file-name">*GNU Emacs*</span>&nbsp;&nbsp;All&nbsp;&nbsp;(L<span id="emacs-line">1</span>,C<span id="emacs-col">0</span>)&nbsp;&nbsp;(<span id="emacs-mode">Fundamental</span>)
   </div>
 
   <!-- ── Shortcuts Hint ────────────────────────────────────────────────── -->
-  <div id="text-editor-shortcuts" class="emacs-shortcuts">
+  <div id="emacs-shortcuts" class="emacs-shortcuts">
     [C-x C-s] Save &nbsp;[C-x C-c] Quit &nbsp;[C-s] Search &nbsp;[C-k] Kill Line &nbsp;[C-_] Undo &nbsp;[C-g] Abort
   </div>
 
   <!-- ── Minibuffer ────────────────────────────────────────────────────── -->
-  <div id="text-editor-minibuffer" class="emacs-minibuffer"></div>
+  <div id="emacs-minibuffer" class="emacs-minibuffer">
+    <div id="emacs-minibuffer-content">
+      <span id="emacs-minibuffer-label"></span>
+      <input id="emacs-minibuffer-input" type="text" autocomplete="off" spellcheck="false" />
+    </div>
+    <span id="emacs-minibuffer-msg"></span>
+  </div>
 
 </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,7 @@ import Terminal from '../components/features/Terminal.astro';
 import FileManager from '../components/features/FileManager.astro';
 import StyleManager from '../components/features/style/StyleManager.astro';
 import ProcessMonitor from '../components/features/ProcessMonitor.astro';
-import TextEditor from '../components/features/TextEditor.astro';
+import Emacs from '../components/features/Emacs.astro';
 import DesktopIcons from '../components/desktop/DesktopIcons.astro';
 import Calendar from '../components/features/Calendar.astro';
 import TerminalLab from '../components/features/TerminalLab.astro';
@@ -41,8 +41,8 @@ import TimeManager from '../components/features/TimeManager.astro';
     <!-- StyleManager -->
     <StyleManager />
 
-    <!-- TextEditor -->
-    <TextEditor />
+    <!-- Emacs -->
+    <Emacs />
 
     <!-- Process Monitor -->
     <ProcessMonitor />

--- a/src/scripts/boot/init.ts
+++ b/src/scripts/boot/init.ts
@@ -268,7 +268,7 @@ function initDesktop(): void {
       window.AudioManager.success();
     }
 
-    // WindowManager owns drag for ALL windows (StyleManager, Terminal, FileManager, TextEditor).
+    // WindowManager owns drag for ALL windows (StyleManager, Terminal, FileManager, Emacs).
     // initDraggableTitlebars() runs after a 200ms delay to ensure the DOM is fully settled.
     WindowManager.init();
     logger.log('[initDesktop] Window manager initialized');

--- a/src/scripts/core/index.ts
+++ b/src/scripts/core/index.ts
@@ -5,7 +5,7 @@ import '../boot/init';
 import '../features/filemanager';
 import '../features/terminal';
 import '../features/stylemanager';
-import '../features/texteditor';
+import '../features/emacs';
 import '../features/lab';
 import '../features/appmanager';
 import '../features/timemanager';

--- a/src/scripts/features/desktop.ts
+++ b/src/scripts/features/desktop.ts
@@ -21,7 +21,7 @@ const SYSTEM_ICONS: any[] = [
     name: 'Emacs',
     icon: '/icons/emacs22.png',
     action: () => {
-      if ((window as any).TextEditor?.openSplash) (window as any).TextEditor.openSplash();
+      if ((window as any).Emacs?.openSplash) (window as any).Emacs.openSplash();
     },
   },
   {
@@ -336,10 +336,10 @@ export const DesktopManager = (() => {
         if (window.openPath) window.openPath(path);
       }
     } else {
-      if ((window as any).openTextEditor) {
+      if ((window as any).openEmacs) {
         const node = VFS.getNode(path);
         const content = node && node.type === 'file' ? node.content : '';
-        await (window as any).openTextEditor(name, content, path);
+        await (window as any).openEmacs(name, content, path);
       }
     }
   }
@@ -522,10 +522,10 @@ export const DesktopManager = (() => {
             },
           },
           {
-            label: 'Text Editor',
+            label: 'Emacs',
             icon: '/icons/text-x-generic.png',
             action: async () => {
-              if (window.TextEditor?.open) window.TextEditor.open();
+              if (window.Emacs?.open) window.Emacs.open();
             },
           },
           {

--- a/src/scripts/features/filemanager.ts
+++ b/src/scripts/features/filemanager.ts
@@ -254,8 +254,8 @@ async function rename(oldName: string, newName: string): Promise<void> {
 }
 
 async function openTextWindow(name: string, content: string): Promise<void> {
-  if (window.openTextEditor) {
-    await window.openTextEditor(name, content);
+  if (window.openEmacs) {
+    await window.openEmacs(name, content);
   }
 }
 


### PR DESCRIPTION
- Replaced CDEModal pop-ups with a native-feeling interactive minibuffer.
- Implemented [promptMinibuffer](cci:1://file:///c:/Users/victx/Documents/GitHub/debian-cde/src/scripts/features/emacs.ts:214:2-230:3) for `M-x`, `C-x C-f`, and `C-x C-w`.
- Improved keyboard focus management for splash screen shortcuts and editor redirection.
- Consolidated Emacs-specific CSS selectors and cleaned up legacy `TextEditor` references.
- Fixed launch regression in `EmacsManager` initialization.