### PR TITLE
feat(pwa): add advanced PWA support with SW, manifest and mobile install

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "Debian CDE Desktop",
+  "short_name": "Debian CDE",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "description": "Retro Debian CDE Desktop UI inspirado en Unix y Linux.",
+  "lang": "es-MX",
+  "icons": [
+    {
+      "src": "/icons/Debian.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icons/Debian.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,91 @@
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `static-cache-${CACHE_VERSION}`;
+
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/css/core.css',
+  '/css/components.css',
+  '/css/app.css',
+  '/css/responsive.css',
+  '/icons/cursor.svg',
+  '/icons/cursor-wait.svg',
+  '/icons/cursor-move.svg',
+  '/icons/cursor-resize-nw.svg',
+  '/icons/fsf.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== STATIC_CACHE)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(request.url);
+
+  // Navegación: estrategia network-first con fallback a caché
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const responseClone = response.clone();
+          caches.open(STATIC_CACHE).then((cache) => cache.put(request, responseClone));
+          return response;
+        })
+        .catch(() =>
+          caches.match(request).then((cached) => cached || caches.match('/'))
+        )
+    );
+    return;
+  }
+
+  // Recursos estáticos propios: cache-first
+  if (url.origin === self.location.origin) {
+    if (
+      url.pathname.startsWith('/css/') ||
+      url.pathname.startsWith('/icons/') ||
+      url.pathname.startsWith('/backdrops/') ||
+      url.pathname.startsWith('/palettes/')
+    ) {
+      event.respondWith(
+        caches.match(request).then((cached) => {
+          if (cached) {
+            return cached;
+          }
+
+          return fetch(request).then((response) => {
+            const responseClone = response.clone();
+            caches.open(STATIC_CACHE).then((cache) => cache.put(request, responseClone));
+            return response;
+          });
+        })
+      );
+      return;
+    }
+  }
+
+  // Resto: network-first con fallback opcional a caché
+  event.respondWith(
+    fetch(request).catch(() => caches.match(request))
+  );
+});
+

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -13,6 +13,9 @@ const { title } = Astro.props;
     <meta name="description" content="Retro Debian CDE Desktop UI inspirado en Unix y Linux." />
     <meta name="keywords" content="Debian, Linux, CDE, Retro Desktop, Unix" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>{title}</title>
 
     <!-- Critical CSS for Boot Sequence - Inlined to prevent Render Blocking -->
@@ -54,7 +57,9 @@ const { title } = Astro.props;
       }
     </style>
 
-    <link rel="shortcut icon" type="image/x-icon" href="/icons/favicon.ico" />
+    <link rel="icon" type="image/png" href="/icons/Debian.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="/icons/Debian.png" />
 
     <!-- Defer non-critical CSS -->
     <link rel="stylesheet" href="/css/core.css" media="print" onload="this.media='all'" />

--- a/src/scripts/core/index.ts
+++ b/src/scripts/core/index.ts
@@ -9,3 +9,37 @@ import '../features/emacs';
 import '../features/lab';
 import '../features/appmanager';
 import '../features/timemanager';
+
+if (typeof window !== 'undefined') {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker
+        .register('/sw.js')
+        .catch((error) => {
+          console.error('Service worker registration failed', error);
+        });
+    });
+  }
+
+  let deferredInstallPrompt: any = null;
+
+  window.addEventListener('beforeinstallprompt', (event: Event) => {
+    event.preventDefault();
+    deferredInstallPrompt = event as any;
+
+    const shouldInstall = window.confirm(
+      '¿Quieres instalar el escritorio Debian CDE en tu dispositivo?'
+    );
+
+    if (!shouldInstall || !deferredInstallPrompt) {
+      deferredInstallPrompt = null;
+      return;
+    }
+
+    deferredInstallPrompt.prompt();
+
+    deferredInstallPrompt.userChoice.finally(() => {
+      deferredInstallPrompt = null;
+    });
+  });
+}


### PR DESCRIPTION
Configure manifest.webmanifest with Debian icons and PWA metadata. Implement sw.js with shell precache, static/dynamic caching and cache versioning. Register the service worker from core/index.ts without breaking existing logic. Add PWA meta tags and use Debian.png as main icon in the layout. Implement mobile install prompt using beforeinstallprompt on supported browsers.