### PR TITLE
feat(ux): implement retro window animations and refined system sounds

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -421,7 +421,7 @@
 }
 
 /* Remove specific toggle rule as JS handles it, but keep for fallback */
-.open + .dropdown-menu {
+.open+.dropdown-menu {
   display: block;
 }
 
@@ -529,6 +529,41 @@
   user-select: none;
   display: flex;
   flex-direction: column;
+  /* Animation preparation */
+  transition: opacity 0.2s ease-out, transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.window-opening {
+  animation: window-pop-in 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.window-closing {
+  animation: window-shrink-out 0.2s ease-in forwards;
+  pointer-events: none;
+}
+
+@keyframes window-pop-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.9) translateY(10px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes window-shrink-out {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(0.9) translateY(10px);
+  }
 }
 
 .cde-retro-modal {
@@ -1157,6 +1192,7 @@
 
 /* Ajustes responsivos */
 @media (max-width: 480px) {
+
   #cde-modal-global,
   .cde-retro-modal.cde-modal-global {
     width: 95vw;
@@ -2007,7 +2043,7 @@
   flex: 1;
 }
 
-#styleManagerMouse .mouse-control-column > span {
+#styleManagerMouse .mouse-control-column>span {
   font-weight: bold;
   font-size: 11px;
   display: block;
@@ -2120,7 +2156,7 @@
 }
 
 /* Mostrar cuando el botón está abierto */
-#utilitiesBtn.open + #utilitiesDropdown {
+#utilitiesBtn.open+#utilitiesDropdown {
   display: block;
 }
 

--- a/src/scripts/boot/init.ts
+++ b/src/scripts/boot/init.ts
@@ -80,9 +80,9 @@ class DebianRealBoot {
         const timestamp = totalTime.toFixed(6).padStart(12, ' ');
         const text =
           phase.name === 'kernel' ||
-          phase.name === 'cpu' ||
-          phase.name === 'fs' ||
-          phase.name === 'memory'
+            phase.name === 'cpu' ||
+            phase.name === 'fs' ||
+            phase.name === 'memory'
             ? `[ ${timestamp} ] ${msg.text}`
             : msg.text;
 
@@ -265,7 +265,7 @@ function initDesktop(): void {
 
     // Play startup sound
     if (window.AudioManager) {
-      window.AudioManager.success();
+      window.AudioManager.playStartupChime();
     }
 
     // WindowManager owns drag for ALL windows (StyleManager, Terminal, FileManager, Emacs).

--- a/src/scripts/core/audiomanager.ts
+++ b/src/scripts/core/audiomanager.ts
@@ -88,7 +88,7 @@ export const AudioManager = (() => {
             logger.log('[AudioManager] AudioContext unlocked via user gesture');
             removeListeners();
           })
-          .catch(() => {});
+          .catch(() => { });
       } else if (audioCtx && audioCtx.state === 'running') {
         removeListeners();
       }
@@ -139,10 +139,8 @@ export const AudioManager = (() => {
     },
 
     error(): void {
-      this.playMelody([
-        { freq: 200, duration: 0.1, type: 'square', delay: 0 },
-        { freq: 150, duration: 0.2, type: 'square', delay: 120 },
-      ]);
+      playTone(300, 0.1, 'square', 0.5);
+      setTimeout(() => playTone(200, 0.2, 'square', 0.5), 100);
     },
 
     success(): void {
@@ -183,10 +181,13 @@ export const AudioManager = (() => {
     },
 
     playStartupChime(): void {
+      // Classic 90s polyphonic FM-style startup sequence
       this.playMelody([
-        { freq: 392.0, duration: 0.15, type: 'sine' }, // G4
-        { freq: 523.25, duration: 0.15, type: 'sine', delay: 50 }, // C5
-        { freq: 659.25, duration: 0.3, type: 'sine', delay: 50 }, // E5
+        { freq: 261.63, duration: 0.1, type: 'sine' }, // C4
+        { freq: 329.63, duration: 0.1, type: 'sine', delay: 50 }, // E4
+        { freq: 392.00, duration: 0.1, type: 'sine', delay: 50 }, // G4
+        { freq: 523.25, duration: 0.3, type: 'sine', delay: 50 }, // C5
+        { freq: 659.25, duration: 0.4, type: 'sine', delay: 100 }, // E5
       ]);
     },
 

--- a/src/scripts/features/emacs.ts
+++ b/src/scripts/features/emacs.ts
@@ -175,7 +175,7 @@ class EmacsManager {
 
     this.message('Welcome to XEmacs');
 
-    this.win.style.display = 'flex';
+    WindowManager.showWindow('emacs');
     this.win.style.zIndex = String(++this.zIndex);
 
     // Reset size to defaults if they were messed up, but respecting viewport
@@ -201,7 +201,7 @@ class EmacsManager {
     this.updateModeLine();
     this.message(`Loaded: ${filename}`);
 
-    this.win.style.display = 'flex';
+    WindowManager.showWindow('emacs');
     this.win.style.zIndex = String(++this.zIndex);
 
     // Reset size to defaults

--- a/src/scripts/features/filemanager.ts
+++ b/src/scripts/features/filemanager.ts
@@ -741,21 +741,19 @@ function initFileManager(): void {
 window.openFileManager = () => {
   const win = document.getElementById('fm');
   if (win) {
-    win.style.display = 'flex';
+    WindowManager.showWindow('fm');
     win.style.zIndex = String(++zIndex);
     WindowManager.centerWindow(win);
-    if (window.AudioManager) window.AudioManager.windowOpen();
     initFileManager();
     openPath(currentPath);
-    if (window.focusWindow) window.focusWindow('fm');
   }
 };
 
 window.closeFileManager = () => {
   const win = document.getElementById('fm');
   if (win) {
-    win.style.display = 'none';
-    if (window.AudioManager) window.AudioManager.windowClose();
+    if (window.minimizeWindow) window.minimizeWindow('fm');
+    else win.style.display = 'none';
   }
 };
 

--- a/src/scripts/features/netscape.ts
+++ b/src/scripts/features/netscape.ts
@@ -220,27 +220,24 @@ class NetscapeNavigator {
   // ── Window controls ─────────────────────────────────────────────────────
 
   public open(): void {
+    WindowManager.showWindow(this.id);
+
     const win = document.getElementById(this.id);
-    if (!win) return;
-
-    win.style.display = 'flex';
-    win.style.flexDirection = 'column';
-    win.style.zIndex = '10000';
-
-    requestAnimationFrame(() => {
+    if (win) {
+      win.style.flexDirection = 'column';
+      win.style.zIndex = '10000';
       WindowManager.centerWindow(win);
-      if (window.focusWindow) window.focusWindow(this.id);
-    });
-
-    if (window.AudioManager) window.AudioManager.windowOpen();
+    }
     logger.log('[Netscape] Window opened');
   }
 
   public close(): void {
-    const win = document.getElementById(this.id);
-    if (!win) return;
-    win.style.display = 'none';
-    if (window.AudioManager) window.AudioManager.windowClose();
+    if (window.minimizeWindow) window.minimizeWindow(this.id);
+    else {
+      const win = document.getElementById(this.id);
+      if (win) win.style.display = 'none';
+      if (window.AudioManager) window.AudioManager.windowClose();
+    }
     logger.log('[Netscape] Window closed');
   }
 
@@ -307,8 +304,8 @@ class NetscapeNavigator {
     if (activeBtn) activeBtn.classList.add('active');
 
     // Update nav buttons state
-    const backBtn = document.getElementById('ns-btn-back');
-    const fwdBtn = document.getElementById('ns-btn-forward');
+    const backBtn = document.getElementById('ns-btn-back') as HTMLButtonElement | null;
+    const fwdBtn = document.getElementById('ns-btn-forward') as HTMLButtonElement | null;
     if (backBtn) backBtn.disabled = this.historyIndex <= 0;
     if (fwdBtn) fwdBtn.disabled = this.historyIndex >= this.history.length - 1;
 
@@ -325,7 +322,7 @@ class NetscapeNavigator {
     if (this.isLoading) this.stopLoading();
     this.isLoading = true;
 
-    const stopBtn = document.getElementById('ns-btn-stop');
+    const stopBtn = document.getElementById('ns-btn-stop') as HTMLButtonElement | null;
     if (stopBtn) stopBtn.disabled = false;
 
     const nsLogo = document.getElementById('nsNLogo');
@@ -377,7 +374,7 @@ class NetscapeNavigator {
 
   private stopLoading(): void {
     this.isLoading = false;
-    const stopBtn = document.getElementById('ns-btn-stop');
+    const stopBtn = document.getElementById('ns-btn-stop') as HTMLButtonElement | null;
     if (stopBtn) stopBtn.disabled = true;
 
     const nsLogo = document.getElementById('nsNLogo');
@@ -594,4 +591,4 @@ if (typeof window !== 'undefined') {
   (window as any).openNetscape = () => netscape.open();
 }
 
-export {};
+export { };


### PR DESCRIPTION
- UI/UX: Added CSS "pop-in" and "shrink-out" transitions for windows (0.2s duration).
- Audio: Upgraded system sounds with 90s-style synthesized sequences for Startup (chime) and Errors (beep-boop).
- WindowManager: Centralized showWindow() and minimizeWindow() logic to handle life-cycle animations and audio triggers.
- Apps: Integrated smooth transitions into Emacs, File Manager, and Netscape Navigator.
- Maintenance: Fixed TypeScript lint errors in Netscape navigation controls.