### PR TITLE
fix: improve mobile responsiveness across multiple components

### DIFF
--- a/public/css/components/file-manager.css
+++ b/public/css/components/file-manager.css
@@ -391,31 +391,32 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 2px;
   width: auto;
-  max-width: 85vw;
-  max-height: 70vh;
+  max-width: 40vw;
+  max-height: 35vh;
   overflow: auto;
-  padding: 6px;
+  padding: 2px;
+  margin: 0 auto;
   background: var(--cde-gray-dark);
-  border: 4px ridge var(--border-light);
-  box-shadow: inset 2px 2px 5px rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--border-light);
+  box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.3);
 }
 
 .screenshot-preview-image {
   max-width: 100%;
   height: auto;
   image-rendering: pixelated;
-  border: 2px solid #000;
-  box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.2);
+  border: 1px solid #000;
+  box-shadow: 1px 1px 0px rgba(0, 0, 0, 0.2);
 }
 
 .screenshot-info {
   font-family: 'Inter', sans-serif;
-  font-size: 11px;
+  font-size: 9px;
   color: var(--text-color);
   text-shadow: 1px 1px 0px #000;
   background: rgba(0, 0, 0, 0.3);
-  padding: 4px 8px;
-  border-radius: 2px;
+  padding: 1px 4px;
+  border-radius: 1px;
 }

--- a/public/css/components/lynx.css
+++ b/public/css/components/lynx.css
@@ -130,12 +130,12 @@
   #lynx {
     width: 95vw !important;
     height: auto !important;
-    max-height: calc(100vh - 95px) !important;
+    max-height: calc(100vh - 106px) !important;
     min-width: unset !important;
     min-height: unset !important;
     max-width: 100vw !important;
-    left: auto !important;
-    top: auto !important;
+    left: 2.5vw !important;
+    top: 28px !important;
     position: absolute !important;
     box-sizing: border-box !important;
   }
@@ -175,7 +175,7 @@
 @media (max-width: 479px) {
   #lynx {
     width: 95vw !important;
-    max-height: calc(100vh - 95px) !important;
+    max-height: calc(100vh - 106px) !important;
   }
 
   .lynx-content {

--- a/public/css/components/manviewer.css
+++ b/public/css/components/manviewer.css
@@ -155,12 +155,12 @@
   #man-viewer {
     width: 95vw !important;
     height: auto !important;
-    max-height: calc(100vh - 95px) !important;
+    max-height: calc(100vh - 106px) !important;
     min-width: unset !important;
     min-height: unset !important;
     max-width: 100vw !important;
-    left: auto !important;
-    top: auto !important;
+    left: 2.5vw !important;
+    top: 28px !important;
     position: absolute !important;
     box-sizing: border-box !important;
   }
@@ -198,7 +198,7 @@
 @media (max-width: 479px) {
   #man-viewer {
     width: 95vw !important;
-    max-height: calc(100vh - 95px) !important;
+    max-height: calc(100vh - 106px) !important;
   }
 
   .man-content {

--- a/public/css/components/windows.css
+++ b/public/css/components/windows.css
@@ -173,6 +173,19 @@
   overflow: hidden;
 }
 
+/* Mobile: Ensure maximized windows respect topbar and dock */
+@media (max-width: 768px) {
+  .window.maximized,
+  .cde-retro-modal.maximized {
+    top: 28px !important;
+    left: 0 !important;
+    width: 100vw !important;
+    height: calc(100vh - 106px) !important;
+    max-width: 100vw !important;
+    max-height: calc(100vh - 106px) !important;
+  }
+}
+
 /* General rules for maximized window content */
 .window.maximized .terminal-body,
 .window.maximized .fm-container,

--- a/public/css/responsive.css
+++ b/public/css/responsive.css
@@ -259,8 +259,15 @@
     padding: 0 6px 6px 6px;
   }
 
+  /* Terminal Lab & XEmacs Menubar - Make scrollable on mobile */
+  .te-menubar,
+  .emacs-menubar {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+  }
+
   /* File Manager */
-  #fm {
+  #fm:not(.maximized) {
     width: 300px !important;
     height: 280px !important;
   }
@@ -580,8 +587,15 @@
     width: 340px !important;
   }
 
+  /* Terminal Lab & XEmacs Menubar - Make scrollable on mobile */
+  .te-menubar,
+  .emacs-menubar {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+  }
+
   /* File Manager */
-  #fm {
+  #fm:not(.maximized) {
     width: 380px !important;
   }
 
@@ -637,15 +651,22 @@
     max-height: 85vh !important;
   }
 
-  #terminal {
+  #terminal:not(.maximized) {
     height: 200px !important;
   }
 
-  #fm {
+  /* Terminal Lab & XEmacs Menubar - Make scrollable on mobile landscape */
+  .te-menubar,
+  .emacs-menubar {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+  }
+
+  #fm:not(.maximized) {
     height: 200px !important;
   }
 
-  #process-monitor {
+  #process-monitor:not(.maximized) {
     height: 300px !important;
   }
 


### PR DESCRIPTION
- Fixed File Manager maximization on mobile using :not(.maximized) selector
- Reduced snapshot preview size (40vw x 35vh) and centered container
- Fixed Lynx and Man Viewer positioning to respect topbar (28px) and dock (78px)
- Made Terminal Lab and XEmacs menubars horizontally scrollable on mobile
- Added overflow-x: auto to menubars in all mobile breakpoints