### PR TITLE
feat: implement authentic CDE window shading (roll up/unshade)

### DIFF
--- a/public/css/components/windows.css
+++ b/public/css/components/windows.css
@@ -252,3 +252,21 @@
   border: 4px dashed var(--border-inset-dark) !important;
   pointer-events: none;
 }
+
+/* Window Shading (CDE behavior) */
+.window.shaded,
+.cde-retro-modal.shaded {
+  overflow: hidden !important;
+  transition: height 0.2s ease-out;
+  min-height: 0 !important; /* Override any min-height when shaded */
+}
+
+.window.shaded > *:not(.titlebar),
+.cde-retro-modal.shaded > *:not(.titlebar) {
+  display: none !important;
+}
+
+.window.shaded .titlebar,
+.cde-retro-modal.shaded .titlebar {
+  border-bottom: none;
+}


### PR DESCRIPTION
feat: implement authentic CDE window shading (roll up/unshade)

- Add double-click titlebar to shade/unshade windows (iconic CDE behavior)
- Implement manual double-click detection with 300ms window to work with drag system
- Use capture phase event handling to intercept before drag handler
- Add smooth 0.2s transition animation when shading/unshading
- Add shadeWindow() function to WindowManager with state persistence
- Play click sound on shade/unshade for audio feedback
- Works on both desktop and mobile devices
- Maintains window position and width when shaded
- Allows dragging shaded windows (titlebar only visible)